### PR TITLE
add exchange_options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,12 @@ accelerate throughput a little bit; lower settings help adhere to
 A dictionary of values that will be passed as kwargs when aioamqp attempts
 to connect to the RabbitMQ server.
 
+``exchange_options``
+~~~~~~~~~~~~~~~~~~
+
+A dictionary of values that will be merged with the default exchange options.
+exchange_options: { name: 'groups', type: 'direct', routing_prefix: 'groups' }
+
 Design decisions
 ----------------
 

--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,12 @@ already has ``local_capacity - 1`` messages in memory. Higher settings
 accelerate throughput a little bit; lower settings help adhere to
 ``local_capacity`` more rigorously.
 
+``connection_options``
+~~~~~~~~~~~~~~~~~~
+
+A dictionary of values that will be passed as kwargs when aioamqp attempts
+to connect to the RabbitMQ server.
+
 Design decisions
 ----------------
 

--- a/channels_rabbitmq/connection.py
+++ b/channels_rabbitmq/connection.py
@@ -437,8 +437,9 @@ class Connection:
         self._is_connected = False
 
         logger.info("Channels connecting to RabbitMQ at %s", self.host)
-        transport, protocol = await aioamqp.from_url(self.host,
-                                                     **self.connection_options)
+        transport, protocol = await aioamqp.from_url(
+            self.host, **self.connection_options
+        )
 
         logger.debug("Connected; setting up")
         channel = await protocol.channel()

--- a/channels_rabbitmq/connection.py
+++ b/channels_rabbitmq/connection.py
@@ -335,6 +335,7 @@ class Connection:
         prefetch_count=10,
         expiry=60,
         group_expiry=86400,
+        connection_options={},
     ):
         self.loop = loop
         self.host = host
@@ -344,6 +345,7 @@ class Connection:
         self.expiry = expiry
         self.group_expiry = group_expiry
         self.queue_name = queue_name
+        self.connection_options = connection_options
 
         # incoming_messages: await `get()` on any channel-name queue to receive
         # the next message. If the `get()` is canceled, that's probably because
@@ -435,7 +437,8 @@ class Connection:
         self._is_connected = False
 
         logger.info("Channels connecting to RabbitMQ at %s", self.host)
-        transport, protocol = await aioamqp.from_url(self.host)
+        transport, protocol = await aioamqp.from_url(self.host,
+                                                     **self.connection_options)
 
         logger.debug("Connected; setting up")
         channel = await protocol.channel()

--- a/channels_rabbitmq/connection.py
+++ b/channels_rabbitmq/connection.py
@@ -12,10 +12,6 @@ from channels.exceptions import ChannelFull
 
 logger = logging.getLogger(__name__)
 
-from django.conf import settings
-def setting(name, default=None):
-    return getattr(settings, name, default)
-
 ReconnectDelay = 1.0  # seconds
 
 def routing_group(group, prefix=None):

--- a/channels_rabbitmq/core.py
+++ b/channels_rabbitmq/core.py
@@ -50,13 +50,15 @@ class RabbitmqChannelLayer(BaseChannelLayer):
         prefetch_count=10,
         expiry=60,
         group_expiry=86400,
+        connection_options={},
     ):
         self.host = host
         self.local_capacity = local_capacity
         self.remote_capacity = remote_capacity
         self.prefetch_count = prefetch_count
         self.expiry = expiry
-        self.group_expiry = 86400
+        self.group_expiry = group_expiry
+        self.connection_options = connection_options
 
         # In inefficient client code (e.g., async_to_sync()), there may be
         # several send() or receive() calls within different event loops --
@@ -88,6 +90,7 @@ class RabbitmqChannelLayer(BaseChannelLayer):
             prefetch_count=self.prefetch_count,
             expiry=self.expiry,
             group_expiry=self.group_expiry,
+            connection_options=self.connection_options,
         )
         self._connections[loop] = connection  # assume lock is held
 

--- a/channels_rabbitmq/core.py
+++ b/channels_rabbitmq/core.py
@@ -51,6 +51,7 @@ class RabbitmqChannelLayer(BaseChannelLayer):
         expiry=60,
         group_expiry=86400,
         connection_options={},
+        exchange_options={}
     ):
         self.host = host
         self.local_capacity = local_capacity
@@ -59,6 +60,12 @@ class RabbitmqChannelLayer(BaseChannelLayer):
         self.expiry = expiry
         self.group_expiry = group_expiry
         self.connection_options = connection_options
+        self.exchange_options = { 
+            'name': 'groups', 
+            'type': 'direct', 
+            'routing_prefix': 'groups', 
+            **exchange_options,
+        }
 
         # In inefficient client code (e.g., async_to_sync()), there may be
         # several send() or receive() calls within different event loops --
@@ -91,6 +98,7 @@ class RabbitmqChannelLayer(BaseChannelLayer):
             expiry=self.expiry,
             group_expiry=self.group_expiry,
             connection_options=self.connection_options,
+            exchange_options=self.exchange_options,
         )
         self._connections[loop] = connection  # assume lock is held
 


### PR DESCRIPTION
Allows choosing exchange type and name and routing_key prefix.
Chained on changes for connection_options (which is not merged upstream yet). Perhaps this can be pulled in with/after connection_options upstream.